### PR TITLE
fix export on macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,9 @@ jobs:
         run: |
           mkdir -p package/godot_wry
           mv godot/addons package/godot_wry
+          mkdir -p package/godot_wry/bin/libgodot_wry.framework/Resources
+          cp package/godot_wry/bin/libgodot_wry.dylib package/godot_wry/bin/libgodot_wry.framework/libgodot_wry.dylib
+          cp assets/Info.plist package/godot_wry/bin/libgodot_wry.framework/Resources/Info.plist
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,14 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: "--locked --release"
           strip: true
+      - name: Build macOS-specific library
+        if: ${{ matrix.platform.target == 'aarch64-apple-darwin' }}
+        run: |
+          mkdir rust/target/${{ matrix.platform.target }}/release/libgodot_wry.framework
+          mv rust/target/${{ matrix.platform.target }}/release/libgodot_wry.dylib \
+              rust/target/${{ matrix.platform.target }}/release/libgodot_wry.framework/libgodot_wry.dylib
+          mkdir rust/target/${{ matrix.platform.target }}/release/libgodot_wry.framework/Resources
+          cp assets/Info.plist rust/target/${{ matrix.platform.target }}/release/libgodot_wry.framework/Resources/Info.plist
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -45,6 +53,7 @@ jobs:
             rust/target/${{ matrix.platform.target }}/release/*.dll
             rust/target/${{ matrix.platform.target }}/release/*.so
             rust/target/${{ matrix.platform.target }}/release/*.dylib
+            rust/target/${{ matrix.platform.target }}/release/*.framework
 
   zip:
     name: 📦 Package
@@ -61,9 +70,6 @@ jobs:
         run: |
           mkdir -p package/godot_wry
           mv godot/addons package/godot_wry
-          mkdir -p package/godot_wry/bin/libgodot_wry.framework/Resources
-          cp package/godot_wry/bin/libgodot_wry.dylib package/godot_wry/bin/libgodot_wry.framework/libgodot_wry.dylib
-          cp assets/Info.plist package/godot_wry/bin/libgodot_wry.framework/Resources/Info.plist
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/assets/Info.plist
+++ b/assets/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>libgodotsteam</string>
+	<string>libgodot_wry</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>

--- a/assets/Info.plist
+++ b/assets/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>libgodot_wry.dylib</string>
+	<key>CFBundleIdentifier</key>
+	<string>doceazedo.godot_wry.libgodot_wry</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>libgodotsteam</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.5</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>0.0.5</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.12</string>
+</dict>
+</plist>

--- a/godot/addons/godot_wry/WRY.gdextension
+++ b/godot/addons/godot_wry/WRY.gdextension
@@ -7,11 +7,20 @@ reloadable = true
 linux.debug.x86_64     = "bin/x86_64-unknown-linux-gnu/libgodot_wry.so"
 linux.release.x86_64   = "bin/x86_64-unknown-linux-gnu/libgodot_wry.so"
 
-macos.debug.arm64      = "bin/aarch64-apple-darwin/libgodot_wry.dylib"
-macos.release.arm64    = "bin/aarch64-apple-darwin/libgodot_wry.dylib"
+macos.debug      = "bin/aarch64-apple-darwin/libgodot_wry.framework"
+macos.release    = "bin/aarch64-apple-darwin/libgodot_wry.framework"
 
 windows.debug.x86_64   = "bin/x86_64-pc-windows-msvc/godot_wry.dll"
 windows.release.x86_64 = "bin/x86_64-pc-windows-msvc/godot_wry.dll"
 
 [icons]
 WebView = "icons/webview.svg"
+
+[dependencies]
+
+macos.debug = {
+  "bin/aarch64-apple-darwin/libgodot_wry.framework" : "Contents/Frameworks"
+}
+macos.release = {
+  "bin/aarch64-apple-darwin/libgodot_wry.framework" : "Contents/Frameworks"
+}

--- a/godot/addons/godot_wry/WRY.gdextension
+++ b/godot/addons/godot_wry/WRY.gdextension
@@ -4,14 +4,14 @@ compatibility_minimum = 4.1
 reloadable = true
 
 [libraries]
-linux.debug.x86_64     = "res://addons/godot_wry/bin/x86_64-unknown-linux-gnu/libgodot_wry.so"
-linux.release.x86_64   = "res://addons/godot_wry/bin/x86_64-unknown-linux-gnu/libgodot_wry.so"
+linux.debug.x86_64     = "bin/x86_64-unknown-linux-gnu/libgodot_wry.so"
+linux.release.x86_64   = "bin/x86_64-unknown-linux-gnu/libgodot_wry.so"
 
-macos.debug.arm64      = "res://addons/godot_wry/bin/aarch64-apple-darwin/libgodot_wry.dylib"
-macos.release.arm64    = "res://addons/godot_wry/bin/aarch64-apple-darwin/libgodot_wry.dylib"
+macos.debug.arm64      = "bin/aarch64-apple-darwin/libgodot_wry.dylib"
+macos.release.arm64    = "bin/aarch64-apple-darwin/libgodot_wry.dylib"
 
-windows.debug.x86_64   = "res://addons/godot_wry/bin/x86_64-pc-windows-msvc/godot_wry.dll"
-windows.release.x86_64 = "res://addons/godot_wry/bin/x86_64-pc-windows-msvc/godot_wry.dll"
+windows.debug.x86_64   = "bin/x86_64-pc-windows-msvc/godot_wry.dll"
+windows.release.x86_64 = "bin/x86_64-pc-windows-msvc/godot_wry.dll"
 
 [icons]
-WebView = "res://addons/godot_wry/icons/webview.svg"
+WebView = "icons/webview.svg"


### PR DESCRIPTION
The patch partially fixes #18. you would need a framework to make macOS export work. You might need a codesign to make it work.