### PR TITLE
Try to fix for X11

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "serde_json",
  "windows 0.61.1",
  "wry",
+ "x11-dl",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,5 +15,6 @@ lazy_static = "1.5.0"
 serde_json = "1.0"
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18.1"
+x11-dl = "2.21.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61.1", features = ["Win32", "Win32_UI", "Win32_UI_WindowsAndMessaging"]}

--- a/rust/src/godot_window.rs
+++ b/rust/src/godot_window.rs
@@ -40,14 +40,52 @@ impl HasWindowHandle for GodotWindow {
 
     #[cfg(target_os = "linux")]
     fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        use godot::classes::display_server;
+        use gtk::gdk::prelude::DisplayExtManual;
+        use x11_dl::xlib::{Xlib, CWEventMask, SubstructureNotifyMask, SubstructureRedirectMask, XSetWindowAttributes, XWindowAttributes};
+
         gtk::init().expect("Failed to initialize gtk");
+        if !gtk::gdk::Display::default().unwrap().backend().is_x11() {
+            panic!("GDK backend must be X11, set environment variable GDK_BACKEND=x11");
+        }
+        let xlib = Xlib::open().expect("Failed to open Xlib");
 
         let display_server = DisplayServer::singleton();
-        let window_handle = display_server.window_get_native_handle(HandleType::WINDOW_HANDLE);
+        let window_xid = display_server.window_get_native_handle(HandleType::WINDOW_HANDLE);
+        let display = display_server.window_get_native_handle(HandleType::DISPLAY_HANDLE);
+
+        unsafe {
+            let attributes: XWindowAttributes = std::mem::zeroed();
+            let mut attributes = std::mem::MaybeUninit::new(attributes).assume_init();
+
+            let ok = (xlib.XGetWindowAttributes)(
+                godot_display as _,
+                godot_window_xid as c_ulong,
+                &mut attributes,
+            );
+
+            if ok != 1 {
+                panic!("Failed to get X11 window attributes");
+            }
+
+            let mut set_attributes: XSetWindowAttributes = std::mem::zeroed();
+            set_attributes.event_mask = attributes.all_event_masks & !SubstructureNotifyMask & !SubstructureRedirectMask;
+            let ok = (xlib.XChangeWindowAttributes)(
+                godot_display as _,
+                godot_window_xid as c_ulong,
+                CWEventMask,
+                &mut set_attributes,
+            );
+
+            if ok != 1 {
+                panic!("Failed to change X11 window attributes");
+            }
+        }
+
         unsafe {
             Ok(WindowHandle::borrow_raw(
                 RawWindowHandle::Xlib(XlibWindowHandle::new({
-                    window_handle as c_ulong
+                    window_xid as c_ulong
                 }))
             ))
         }

--- a/rust/src/godot_window.rs
+++ b/rust/src/godot_window.rs
@@ -46,7 +46,7 @@ impl HasWindowHandle for GodotWindow {
 
         gtk::init().expect("Failed to initialize gtk");
         if !gtk::gdk::Display::default().unwrap().backend().is_x11() {
-            panic!("GDK backend must be X11, set environment variable GDK_BACKEND=x11");
+            panic!("GDK backend must be X11");
         }
         let xlib = Xlib::open().expect("Failed to open Xlib");
 

--- a/rust/src/godot_window.rs
+++ b/rust/src/godot_window.rs
@@ -59,8 +59,8 @@ impl HasWindowHandle for GodotWindow {
             let mut attributes = std::mem::MaybeUninit::new(attributes).assume_init();
 
             let ok = (xlib.XGetWindowAttributes)(
-                godot_display as _,
-                godot_window_xid as c_ulong,
+                display as _,
+                window_xid as c_ulong,
                 &mut attributes,
             );
 
@@ -71,8 +71,8 @@ impl HasWindowHandle for GodotWindow {
             let mut set_attributes: XSetWindowAttributes = std::mem::zeroed();
             set_attributes.event_mask = attributes.all_event_masks & !SubstructureNotifyMask & !SubstructureRedirectMask;
             let ok = (xlib.XChangeWindowAttributes)(
-                godot_display as _,
-                godot_window_xid as c_ulong,
+                display as _,
+                window_xid as c_ulong,
                 CWEventMask,
                 &mut set_attributes,
             );


### PR DESCRIPTION
I've tried to make it "somehow" work on Linux (X11 only), hope not making things worse.
Don't know what to do with Wayland after doing a lot of investigation on it.

![godot_wry](https://github.com/user-attachments/assets/38bb9b0f-0551-4957-b4e5-0538a9d6baac)

**In a brief, I removed `SubstructureNotifyMask | SubstructureRedirectMask` window attributes added by Godot.**
https://github.com/godotengine/godot/blob/4.4/platform/linuxbsd/x11/display_server_x11.cpp#L6221

**The `transparent` attribute is not working and I got some clues.**

1. Enable `display/window/per_pixel_transparency/allowed` in project settings, https://github.com/godotengine/godot/blob/07e41850ef6c7c8bb7b35a39b080600b77e6953a/main/main.cpp#L2551
2. Modify tauri-app/wry code,  after https://github.com/tauri-apps/wry/blob/wry-v0.51.2/src/webkitgtk/mod.rs#L203 add `vbox.set_visual(gdk_window.screen().rgba_visual().as_ref());`, see https://webkitgtk.org/reference/webkit2gtk/2.39.1/method.WebView.set_background_color.html
3. It's "transparent" in a very weird way, you can see through to the ubuntu desktop and visual studio code window underneath.
4. I've traced the process with RenderDoc and I am sure Godot has rendered all images below the webview.

![godot_wry2](https://github.com/user-attachments/assets/437ee4c0-11ed-45b6-8d33-4de42c02f2c5)
