### PR TITLE
 Add HTTP Range Query Support to Custom `res://` Protocol

### DIFF
--- a/rust/src/protocols.rs
+++ b/rust/src/protocols.rs
@@ -50,7 +50,10 @@ pub fn get_res_response(request: Request<Vec<u8>>) -> Response<Cow<'static, [u8]
 
         // assuming the range header is in the format "bytes=start-end"
         let parts: Vec<&str> = range_str[6..].split('-').collect();
-        let (start, end) = (parts[0].parse::<u64>().expect("failed to parse range start"), parts[1].parse::<u64>().expect("failed to parse range end"));
+        let (start, end) = (
+            parts[0].parse::<u64>().expect("failed to parse range start"),
+            parts[1].parse::<u64>().expect("failed to parse range end")
+        );
 
         content_range = Some((start, end));
     }

--- a/rust/src/protocols.rs
+++ b/rust/src/protocols.rs
@@ -43,7 +43,7 @@ pub fn get_res_response(request: Request<Vec<u8>>) -> Response<Cow<'static, [u8]
     let mut content_range: Option<(u64, u64)> = None;
 
     // The client might request a file with Range,
-    // even if we set Accept-Ranges to none, Safari does this with loading media types.
+    // even if we set Accept-Ranges to none, Safari does this while loading media types.
     // So, we MUST implement the Content-Range logic to serve the file correctly.
     if let Some(range) = request.headers().get(RANGE) {
         let range_str = range.to_str().expect("failed to parse Range header");

--- a/rust/src/protocols.rs
+++ b/rust/src/protocols.rs
@@ -5,7 +5,7 @@ use godot::builtin::GString;
 use godot::classes::file_access::ModeFlags;
 use godot::classes::FileAccess;
 use http::{Request, Response};
-use http::header::{CONTENT_TYPE, RANGE};
+use http::header::{ACCEPT_RANGES, CONTENT_RANGE, CONTENT_TYPE, RANGE};
 use lazy_static::lazy_static;
 
 pub fn get_res_response(request: Request<Vec<u8>>) -> Response<Cow<'static, [u8]>> {
@@ -66,8 +66,8 @@ pub fn get_res_response(request: Request<Vec<u8>>) -> Response<Cow<'static, [u8]
                 if start >= file_size {
                     return http::Response::builder()
                         .header(CONTENT_TYPE, *content_type)
-                        .header("Accept-Ranges", "bytes")
-                        .header("Content-Range", format!("bytes */{}", file_size))
+                        .header(ACCEPT_RANGES, "bytes")
+                        .header(CONTENT_RANGE, format!("bytes */{}", file_size))
                         .status(416) // Range Not Satisfiable
                         .body(Cow::from(Vec::new()))
                         .expect("Failed to build 416 response");
@@ -85,8 +85,8 @@ pub fn get_res_response(request: Request<Vec<u8>>) -> Response<Cow<'static, [u8]
 
                 http::Response::builder()
                     .header(CONTENT_TYPE, *content_type)
-                    .header("Accept-Ranges", "bytes")
-                    .header("Content-Range", format!("bytes {}-{}/{}", start, end, file_size))
+                    .header(ACCEPT_RANGES, "bytes")
+                    .header(CONTENT_RANGE, format!("bytes {}-{}/{}", start, end, file_size))
                     .status(206)
                     .body(Cow::from(content))
                     .expect("Failed to build 206 response")

--- a/rust/src/protocols.rs
+++ b/rust/src/protocols.rs
@@ -5,44 +5,107 @@ use godot::builtin::GString;
 use godot::classes::file_access::ModeFlags;
 use godot::classes::FileAccess;
 use http::{Request, Response};
-use http::header::CONTENT_TYPE;
+use http::header::{CONTENT_TYPE, RANGE};
 use lazy_static::lazy_static;
 
-pub fn get_res_response(
-    request: Request<Vec<u8>>,
-) -> Response<Cow<'static, [u8]>> {
+pub fn get_res_response(request: Request<Vec<u8>>) -> Response<Cow<'static, [u8]>> {
     let root = PathBuf::from("res://");
-    let path = format!("{}{}", request.uri().host().unwrap_or_default(), request.uri().path());
+    let path = format!(
+        "{}{}",
+        request.uri().host().unwrap_or_default(),
+        request.uri().path()
+    );
     let full_path = root.join(path);
     let full_path_str = GString::from(full_path.to_str().unwrap_or_default());
 
     if !FileAccess::file_exists(&full_path_str) {
         return http::Response::builder()
-        .header(CONTENT_TYPE, "text/plain")
-        .status(404)
-        .body(Cow::from(format!("Could not find file at {:?}", full_path).as_bytes().to_vec()))
-        .expect("Failed to build 404 response");
+            .header(CONTENT_TYPE, "text/plain")
+            .status(404)
+            .body(Cow::from(
+                format!("Could not find file at {:?}", full_path)
+                    .as_bytes()
+                    .to_vec(),
+            ))
+            .expect("Failed to build 404 response");
     }
+
+    let extension = full_path
+            .extension()
+            .unwrap_or_default()
+            .to_str()
+            .unwrap_or_default();
+
+    let content_type = MIME_TYPES
+            .get(extension)
+            .unwrap_or(&"application/octet-stream");
     
+    let mut content_range: Option<(u64, u64)> = None;
+
+    // The client might request a file with Range,
+    // even if we set Accept-Ranges to none, Safari does this with loading media types.
+    // So, we MUST implement the Content-Range logic to serve the file correctly.
+    if let Some(range) = request.headers().get(RANGE) {
+        let range_str = range.to_str().expect("failed to parse Range header");
+
+        // assuming the range header is in the format "bytes=start-end"
+        let parts: Vec<&str> = range_str[6..].split('-').collect();
+        let (start, end) = (parts[0].parse::<u64>().expect("failed to parse range start"), parts[1].parse::<u64>().expect("failed to parse range end"));
+
+        content_range = Some((start, end));
+    }
+
     return FileAccess::open(&full_path_str, ModeFlags::READ)
-        .map(|file| {
-            let extension = full_path.extension().unwrap_or_default().to_str().unwrap_or_default();
-            let content_type = MIME_TYPES.get(extension).unwrap_or(&"application/octet-stream").clone();
+        .map(|mut file| {
+            let file_size: i64 = file.get_length().try_into().unwrap_or(0);
 
-            let content_size: i64 = file.get_length().try_into().unwrap_or(0);
+            return if let Some((start, end)) = content_range {
+                if start >= file_size as u64 {
+                    return http::Response::builder()
+                        .header(CONTENT_TYPE, *content_type)
+                        .header("Accept-Ranges", "bytes")
+                        .header("Content-Range", format!("bytes */{}", file_size))
+                        .status(416) // Range Not Satisfiable
+                        .body(Cow::from(Vec::new()))
+                        .expect("Failed to build 416 response");
+                }
 
-            let content = file.get_buffer(content_size).as_slice().to_vec();
-            http::Response::builder()
-                .header(CONTENT_TYPE, content_type)
-                .status(200)
-                .body(Cow::from(content))
-                .expect("Failed to build 200 response")
-        })
-        .unwrap_or_else( || {
+                let end = if end == 0 || end >= file_size as u64 {
+                    file_size as u64 - 1
+                } else {
+                    end
+                };
+
+                let content_size = (end - start + 1) as i64;
+                file.seek(start);
+                let content = file.get_buffer(content_size).as_slice().to_vec();
+
+                http::Response::builder()
+                    .header(CONTENT_TYPE, *content_type)
+                    .header("Accept-Ranges", "bytes")
+                    .header("Content-Range", format!("bytes {}-{}/{}", start, end, file_size))
+                    .header("Content-Length", content_size.to_string())
+                    .status(206)
+                    .body(Cow::from(content))
+                    .expect("Failed to build 206 response")
+            } else {
+                let content_size = file_size as i64;
+                let content = file.get_buffer(content_size).as_slice().to_vec();
+                http::Response::builder()
+                    .header(CONTENT_TYPE, *content_type)
+                    .status(200)
+                    .body(Cow::from(content))
+                    .expect("Failed to build 200 response")
+            }
+        }).unwrap_or_else(|| {
             http::Response::builder()
                 .header(CONTENT_TYPE, "text/plain")
-                .status(404)
-                .body(Cow::from(format!("Could not find file at {:?}", full_path).as_bytes().to_vec()))
+                .status(500)
+                .body(Cow::from(
+                    format!("Failed to open at {:?}", full_path)
+                        .as_bytes()
+                        .to_vec(),
+                ))
                 .expect("Failed to build 404 response")
         });
 }


### PR DESCRIPTION
This PR adds support for HTTP Range requests to the custom `res://` protocol handler. This enhancement ensures better compatibility with browsers with WebKit (on macOS and Linux). When we serve video files within the `res://` protocol, the WebKit keeps using `Range` header to query part of the file instead of the full file, even when `Accept-Ranges` explicitly sets to `none`.

Based on the behavior on macOS, we see the Safari query the file multiple times based on the video decoder status no matter if the `Accept-Ranges` is provided or not. For example, it would first query the first two bytes to check if the file contains `ftyp`, later it loads the end of the file to check the codec, etc. In such cases, there might be **several Gigabytes of data sent per second** while playing. This PR fixes that behavior.
