### PR TITLE
add wasm mime type

### DIFF
--- a/rust/src/protocols.rs
+++ b/rust/src/protocols.rs
@@ -175,6 +175,7 @@ lazy_static! {
         ("txt", "text/plain"),
         ("vsd", "application/vnd.visio"),
         ("wav", "audio/wav"),
+        ("wasm", "application/wasm"),
         ("weba", "audio/webm"),
         ("webm", "video/webm"),
         ("webp", "image/webp"),


### PR DESCRIPTION
add mime type for `*.wasm` files, otherwhise, on Edge-based platforms (Windows), this would cause `Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.,`, which affects the loading performance of webassembly.