### PR TITLE
fix modifier keys

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -272,6 +272,11 @@ impl WebView {
                                 
                                 event.set_keycode(godot_key);
                                 event.set_pressed(event_type == "_key_down");
+
+                                event.set_shift_pressed(json_value.get("shift").and_then(|v| v.as_bool()).unwrap_or(false));
+                                event.set_ctrl_pressed(json_value.get("ctrl").and_then(|v| v.as_bool()).unwrap_or(false));
+                                event.set_alt_pressed(json_value.get("alt").and_then(|v| v.as_bool()).unwrap_or(false));
+                                event.set_meta_pressed(json_value.get("meta").and_then(|v| v.as_bool()).unwrap_or(false));
                                 
                                 Input::singleton().parse_input_event(&event);
                                 return;
@@ -353,20 +358,30 @@ impl WebView {
                 });
                 document.addEventListener('keydown', (e) => {
                     if (!document.hasFocus()) return;
+                    const isModifier = ["Alt", "Shift", "Control", "Meta"].includes(e.key);
                     window.ipc.postMessage(JSON.stringify({
                         type: '_key_down',
                         key: e.key,
                         code: e.code,
-                        keyCode: e.keyCode
+                        keyCode: e.keyCode,
+                        shift: isModifier ? false : e.shiftKey,
+                        ctrl: isModifier ? false : e.ctrlKey,
+                        alt: isModifier ? false : e.altKey,
+                        meta: isModifier ? false : e.metaKey
                     }));
                 });
                 document.addEventListener('keyup', (e) => {
                     if (!document.hasFocus()) return;
+                    const isModifier = ["Alt", "Shift", "Control", "Meta"].includes(e.key);
                     window.ipc.postMessage(JSON.stringify({
                         type: '_key_up',
                         key: e.key,
                         code: e.code,
-                        keyCode: e.keyCode
+                        keyCode: e.keyCode,
+                        shift: isModifier ? false : e.shiftKey,
+                        ctrl: isModifier ? false : e.ctrlKey,
+                        alt: isModifier ? false : e.altKey,
+                        meta: isModifier ? false : e.metaKey
                     }));
                 });
             "#;


### PR DESCRIPTION
(All my pull requests have been merged together into a single branch https://github.com/mythridium/godot_wry/tree/custom, I can close these individual ones and open a single pull request if desired)

fixes #56 

WebView modifier input events are now sent identical to the way godot sends them from non webview nodes.

Using this snippet of code.
```
func _input(event: InputEvent) -> void:
	if event is InputEventMouseMotion:
		return
		
	if event is InputEventWithModifiers:
		print(event.meta_pressed);
		print(event.alt_pressed);
		print(event.ctrl_pressed);
		print(event.shift_pressed);
		print(event.as_text());
```

Will output

```
false
false
false
false
Shift
false
false
false
true
Shift+C
false
false
false
true
Shift+C
false
false
false
false
Shift
false
false
false
false
Ctrl
false
false
true
false
Ctrl+C
false
false
true
false
Ctrl+C
false
false
false
false
Ctrl
false
false
false
false
Alt
false
true
false
false
Alt+C
false
true
false
false
Alt+C
false
false
false
false
Alt
```

And a more condensed version removing the modifier logs, both godot and webview send the same input events now.

```
// godot focused
Shift
Shift+Tab
Shift
Tab

// webview focused
Shift
Shift+Tab
Shift
Tab
```