### PR TITLE
add context_menu property

### DIFF
--- a/docs/reference/webview.md
+++ b/docs/reference/webview.md
@@ -20,6 +20,7 @@ The fundamental `Control` node to present a webview.
 | incognito            | bool       | Run the webview with incognito mode.                                                                      |
 | focused_when_created | bool       | Webview will be focused when created.                                                                     |
 | forward_input_events | bool       | Mouse and keyboard events captured by the webview will be propagated to the game.                         |
+| context_menu         | bool       | Enables right-click context menus on **Windows**.                                                         |
 
 ## Methods
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -70,6 +70,8 @@ struct WebView {
     forward_input_events: bool,
     #[export]
     autoplay: bool,
+    #[export]
+    context_menu: bool,
 }
 
 #[godot_api]
@@ -94,6 +96,7 @@ impl IControl for WebView {
             focused_when_created: true,
             forward_input_events: true,
             autoplay: false,
+            context_menu: true
         }
     }
 
@@ -160,7 +163,7 @@ impl WebView {
         }
 
         let base = self.base().clone();
-        let webview_builder = WebViewBuilder::with_attributes(WebViewAttributes {
+        let mut webview_builder = WebViewBuilder::with_attributes(WebViewAttributes {
             url: if self.html.is_empty() { Some(String::from(&self.url)) } else { None },
             html: if self.url.is_empty() { Some(String::from(&self.html)) } else { None },
             transparent: self.transparent,
@@ -291,6 +294,11 @@ impl WebView {
 
         if !self.url.is_empty() && !self.html.is_empty() {
             godot_error!("[Godot WRY] You have entered both a URL and HTML code. You may only enter one at a time.")
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            webview_builder = wry::WebViewBuilderExtWindows::with_default_context_menus(webview_builder, self.context_menu);
         }
 
         let webview = webview_builder.build_as_child(&window).unwrap();


### PR DESCRIPTION
(All my pull requests have been merged together into a single branch https://github.com/mythridium/godot_wry/tree/custom, I can close these individual ones and open a single pull request if desired)

Adds a new export to enable/disable the right click context menu.

This is a windows only feature.

<img width="399" height="521" alt="image" src="https://github.com/user-attachments/assets/68457cf7-fd45-43fd-92f0-e3b38deb78e9" />
