### PR TITLE
fix refresh error and directory load error

### DIFF
--- a/rust/src/protocols.rs
+++ b/rust/src/protocols.rs
@@ -15,7 +15,16 @@ pub fn get_res_response(request: Request<Vec<u8>>) -> Response<Cow<'static, [u8]
         request.uri().host().unwrap_or_default(),
         request.uri().path()
     );
-    let full_path = root.join(path);
+    let mut full_path = root.join(path);
+
+    if full_path.ends_with("/") || full_path.is_dir() || full_path.extension().is_none() {
+        let index_path = full_path.join("index.html");
+        
+        if FileAccess::file_exists(&GString::from(index_path.to_str().unwrap_or_default())) {
+            full_path = index_path;
+        }
+    }
+
     let full_path_str = GString::from(full_path.to_str().unwrap_or_default());
 
     if !FileAccess::file_exists(&full_path_str) {


### PR DESCRIPTION
(All my pull requests have been merged together into a single branch https://github.com/mythridium/godot_wry/tree/custom, I can close these individual ones and open a single pull request if desired)

fixes #57 mostly

It is generally the default behavior for web servers to serve up an `index.html` file if a directory is navigated to if present. If no `index.html` it will show a directory listing, failing that it shows 404.

I don't think we need to implement a directory listing, but this now serves up the `index.html` if a directory is navigated to.

This ends up fixing the majority of issues listed in #57 

1. The directory failure is no longer present and the page loads cleanly with no errors.
2. I couldn't get `res://` to work in the base path, maybe this is a windows thing since it remaps the protocol to `http://res.` but this just kept throwing errors for me. However, this isn't an issue as with these changes using `.` works fine.
3. With the changes in this pull request, reloading the page is also fixed, since the directory serves up the `index.html`.