### PR TITLE
add user_data_directory property

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Use [just](https://github.com/casey/just) to build the extension and move the bi
 $ just build
 ```
 
-If you need a more in-depth guide on how to compile the project, check the [Building from source](https://godot-wry.doceazedo.com/contributing/compiling) documentation page.
+If you need a more in-depth guide on how to compile the project, check the [Building from source](https://godot-wry.doceazedo.com/contributing/compiling.html) documentation page.
 
 ## 📚 Documentation
 
@@ -97,13 +97,13 @@ WRY itself already has [mobile support](https://github.com/tauri-apps/wry/blob/d
 - Different browser engines across platforms
 - No automatic dependency checks
 
-You can learn more about these caveats on the [Caveats](https://godot-wry.doceazedo.com/about/caveats) documentation page.
+You can learn more about these caveats on the [Caveats](https://godot-wry.doceazedo.com/about/caveats.html) documentation page.
 
 ## 🤝 Contribute
 
-Your help is most welcome regardless of form! Check out the [How to contribute](https://godot-wry.doceazedo.com/contributing/how-to-contribute) page for all ways you can contribute to the project. For example, [suggest a new feature](https://github.com/doceazedo/godot_wry/issues/new?template=feature_request.md), [report a problem/bug](https://github.com/doceazedo/godot_wry/issues/new?template=bug_report.md), [submit a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests), or simply use the project and comment your experience.
+Your help is most welcome regardless of form! Check out the [How to contribute](https://godot-wry.doceazedo.com/contributing/how-to-contribute.html) page for all ways you can contribute to the project. For example, [suggest a new feature](https://github.com/doceazedo/godot_wry/issues/new?template=feature_request.md), [report a problem/bug](https://github.com/doceazedo/godot_wry/issues/new?template=bug_report.md), [submit a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests), or simply use the project and comment your experience.
 
-See the [Roadmap](https://godot-wry.doceazedo.com/about/roadmap) documentation page for an idea of how the project should evolve.
+See the [Roadmap](https://godot-wry.doceazedo.com/about/roadmap.html) documentation page for an idea of how the project should evolve.
 
 ## 🎫 License
 

--- a/docs/reference/webview.md
+++ b/docs/reference/webview.md
@@ -4,22 +4,23 @@ The fundamental `Control` node to present a webview.
 
 ## Properties
 
-| Property             | Type       | Description                                                                                               |
-| -------------------- | ---------- | --------------------------------------------------------------------------------------------------------- |
-| full_window_size     | bool       | Webview will always be the same size as the viewport.                                                     |
-| url                  | String     | Initial URL to be loaded. This will override `html`.                                                      |
-| html                 | String     | HTML string to be loaded. This will be ignored if `url` is provided.                                      |
-| transparent          | bool       | Webview should be transparent.                                                                            |
-| autoplay             | bool       | Media can be played without user interaction.                                                             |
-| background_color     | Color      | **🚧 Not implemented.** Webview background color. This will be ignored if `transparent` is set to `true`. |
-| devtools             | bool       | Enables web inspector. To open it, you can call `open_devtools()`, or right click the page and open it.   |
-| headers              | Dictionary | **🚧 Not implemented.** Headers used when loading the requested URL.                                      |
-| user_agent           | String     | Custom user agent header.                                                                                 |
-| zoom_hotkeys         | bool       | Enables page zooming hotkeys.                                                                             |
-| clipboard            | bool       | Enables clipboard access on **Linux** and **Windows**. Always enabled on macOS.                           |
-| incognito            | bool       | Run the webview with incognito mode.                                                                      |
-| focused_when_created | bool       | Webview will be focused when created.                                                                     |
-| forward_input_events | bool       | Mouse and keyboard events captured by the webview will be propagated to the game.                         |
+| Property             | Type       | Description                                                                                                    |
+| -------------------- | ---------- | -------------------------------------------------------------------------------------------------------------- |
+| full_window_size     | bool       | Webview will always be the same size as the viewport.                                                          |
+| url                  | String     | Initial URL to be loaded. This will override `html`.                                                           |
+| html                 | String     | HTML string to be loaded. This will be ignored if `url` is provided.                                           |
+| user_data_directory  | String     | The directory that will be used for browsing data. Supports `user://`, absolute or relative file paths.        |
+| transparent          | bool       | Webview should be transparent.                                                                                 |
+| autoplay             | bool       | Media can be played without user interaction.                                                                  |
+| background_color     | Color      | **🚧 Not implemented.** Webview background color. This will be ignored if `transparent` is set to `true`.      |
+| devtools             | bool       | Enables web inspector. To open it, you can call `open_devtools()`, or right click the page and open it.        |
+| headers              | Dictionary | **🚧 Not implemented.** Headers used when loading the requested URL.                                           |
+| user_agent           | String     | Custom user agent header.                                                                                      |
+| zoom_hotkeys         | bool       | Enables page zooming hotkeys.                                                                                  |
+| clipboard            | bool       | Enables clipboard access on **Linux** and **Windows**. Always enabled on macOS.                                |
+| incognito            | bool       | Run the webview with incognito mode.                                                                           |
+| focused_when_created | bool       | Webview will be focused when created.                                                                          |
+| forward_input_events | bool       | Mouse and keyboard events captured by the webview will be propagated to the game.                              |
 
 ## Methods
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,13 +4,14 @@ mod protocols;
 use godot::global::MouseButtonMask;
 use godot::init::*;
 use godot::prelude::*;
-use godot::classes::{Control, DisplayServer, IControl, Input, InputEventMouseButton, InputEventMouseMotion, InputEventKey};
+use godot::classes::{Control, DisplayServer, IControl, Input, InputEventMouseButton, InputEventMouseMotion, InputEventKey, ProjectSettings};
 use godot::global::{Key, MouseButton};
 use lazy_static::lazy_static;
 use serde_json;
 use std::collections::HashMap;
 use std::sync::Mutex;
-use wry::{WebViewBuilder, Rect, WebViewAttributes};
+use std::path::PathBuf;
+use wry::{WebViewBuilder, WebContext, Rect, WebViewAttributes};
 use wry::dpi::{PhysicalPosition, PhysicalSize};
 use wry::http::Request;
 
@@ -49,6 +50,8 @@ struct WebView {
     #[export]
     html: GString,
     #[export]
+    user_data_directory: GString,
+    #[export]
     transparent: bool,
     #[export]
     background_color: Color,
@@ -83,6 +86,7 @@ impl IControl for WebView {
             full_window_size: true,
             url: "https://github.com/doceazedo/godot_wry".into(),
             html: "".into(),
+            user_data_directory: "".into(),
             transparent: false,
             background_color: Color::from_rgb(1.0, 1.0, 1.0),
             devtools: true,
@@ -160,7 +164,31 @@ impl WebView {
         }
 
         let base = self.base().clone();
+        let resolved_user_dir: Option<PathBuf> = if !self.user_data_directory.is_empty() {
+            let dir = self.user_data_directory.to_string();
+
+            if dir.starts_with("user://") {
+                let sub_path = dir.trim_start_matches("user://");
+
+                let ps = ProjectSettings::singleton();
+                let base_path = ps.globalize_path("user://").to_string();
+                let mut abs_path = PathBuf::from(base_path);
+                abs_path.push(sub_path);
+
+                std::fs::create_dir_all(&abs_path).ok();
+
+                Some(abs_path)
+            } else {
+                let path = PathBuf::from(&dir);
+                std::fs::create_dir_all(&path).ok();
+                Some(path)
+            }
+        } else {
+            None
+        };
+        let mut context = WebContext::new(resolved_user_dir);
         let webview_builder = WebViewBuilder::with_attributes(WebViewAttributes {
+            context: Some(&mut context),
             url: if self.html.is_empty() { Some(String::from(&self.url)) } else { None },
             html: if self.url.is_empty() { Some(String::from(&self.html)) } else { None },
             transparent: self.transparent,


### PR DESCRIPTION
fixes #58 

Adds the ability to configure the user data directory.

<img width="403" height="518" alt="image" src="https://github.com/user-attachments/assets/d3172a3a-e8cb-454b-83ca-b8b2dbd00650" />

<img width="657" height="188" alt="image" src="https://github.com/user-attachments/assets/2139fa0a-d0b6-48b0-866f-69cdd3313181" />

I also fixed the documentation links in the readme as they are leading to broken pages.

This is the first time I've ever looked at rust code, please amend what isn't right as I don't really know what I'm doing, otherwise let me know any changes and I can make them, but I've tested this works with `user://` and relative paths.