### PR TITLE
Fix for Linux: Initialize GTK before WebKitGTK operations

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -156,6 +156,15 @@ impl WebView {
             return;
         }
 
+        // Initialize GTK on Linux before any WebKitGTK operations
+        #[cfg(target_os = "linux")]
+        {
+            if gtk::init().is_err() {
+                godot_error!("Godot WRY: Failed to initialize GTK. WebView will not work.");
+                return;
+            }
+        }
+
         let window = GodotWindow;
 
         // remove WS_CLIPCHILDREN from the window style


### PR DESCRIPTION
 WebKitGTK requires GTK to be initialised before any operations.
 
 Without this, the WebView fails with the 'GTK has not been initialized' error on Linux systems.


 This checks if we're on linux, calls gtk::init() and checks the result:
  - If init succeeds → .is_err() returns false → skip the block → continue to create webview
  - If init fails → .is_err() returns true → log error and return early
  
  Non-destructive and scoped, either fixes it or provides an informative errors.  
  
   Tested on Ubuntu/Pop!_OS with Godot 4.5.