### PR TITLE
Add drag and drop handler, new window handler and document title changed handler, as well as navigation handler

### DIFF
--- a/godot/addons/godot_wry/icons/webview.svg.import
+++ b/godot/addons/godot_wry/icons/webview.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://c6iicr8hnjpnr"
 path="res://.godot/imported/webview.svg-98b4564a2c84894affbef4b93ae62491.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -18,6 +19,8 @@ dest_files=["res://.godot/imported/webview.svg-98b4564a2c84894affbef4b93ae62491.
 compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
+compress/uastc_level=0
+compress/rdo_quality_loss=0.0
 compress/hdr_compression=1
 compress/normal_map=0
 compress/channel_pack=0
@@ -25,6 +28,10 @@ mipmaps/generate=false
 mipmaps/limit=-1
 roughness/mode=0
 roughness/src_normal=""
+process/channel_remap/red=0
+process/channel_remap/green=1
+process/channel_remap/blue=2
+process/channel_remap/alpha=3
 process/fix_alpha_border=true
 process/premult_alpha=false
 process/normal_map_invert_y=false
@@ -33,5 +40,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
+editor/scale_with_editor_scale=true
 editor/convert_colors_with_editor_theme=false

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -11,7 +11,8 @@ config_version=5
 [application]
 
 config/name="WRY"
-config/features=PackedStringArray("4.2", "Forward Plus")
+config/features=PackedStringArray("4.5", "Forward Plus")
+config/icon="uid://c6iicr8hnjpnr"
 
 [display]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "webview2-com-macros"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
+checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]  # Compile this crate to a dynamic C library.
 [dependencies]
 godot = { git = "https://github.com/godot-rust/gdext", branch = "master", features = ["api-4-1"] }
 raw-window-handle = "0.6.2"
-wry = { version = "0.50.4", features = ["transparent", "devtools"] }
+wry = { version = "0.50.3", features = ["transparent", "devtools", "drag-drop"] }
 http = "1.1.0"
 lazy_static = "1.5.0"
 serde_json = "1.0"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -74,6 +74,10 @@ struct WebView {
     forward_input_events: bool,
     #[export]
     autoplay: bool,
+    #[export]
+    drag_and_drop: bool,
+    new_window_req_handler: Callable,
+    navigation_handler: Callable,
 }
 
 #[godot_api]
@@ -100,6 +104,9 @@ impl IControl for WebView {
             focused_when_created: true,
             forward_input_events: true,
             autoplay: false,
+            drag_and_drop: false,
+            new_window_req_handler: Callable::invalid(),
+            navigation_handler: Callable::invalid(),
         }
     }
 
@@ -122,6 +129,9 @@ impl WebView {
 
     #[signal]
     fn page_load_finished(message: GString);
+    
+    #[signal]
+    fn document_title_changed(title: GString);
 
     #[func]
     fn update_webview(&mut self) {
@@ -201,6 +211,9 @@ impl WebView {
             None
         };
         let mut context = WebContext::new(resolved_data_directory);
+        let drag_and_drop_enabled = self.drag_and_drop;
+        let new_window_req_handler = Arc::new(Mutex::new(self.new_window_req_handler.clone()));
+        let navigation_handler = Arc::new(Mutex::new(self.navigation_handler.clone()));
         let webview_builder = WebViewBuilder::with_attributes(WebViewAttributes {
             context: Some(&mut context),
             url: if self.html.is_empty() { Some(String::from(&self.url)) } else { None },
@@ -377,7 +390,41 @@ impl WebView {
             })
             .with_custom_protocol(
                 "res".into(), move |_webview_id, request| get_res_response(request),
-            );
+            )
+            .with_drag_drop_handler(move |_handler| {
+                drag_and_drop_enabled
+            })
+            .with_new_window_req_handler({
+                let new_window_req_handler = Arc::clone(&new_window_req_handler);
+                move |url: String| {
+                    let handler = new_window_req_handler.lock().unwrap();
+                    if handler.is_valid() {
+                        let result = handler.callv(&varray![url.to_variant()]);
+                        return result.booleanize();
+                    }
+                    false
+                }
+            })
+            .with_document_title_changed_handler({
+                let base = Arc::clone(&base);
+                move |title| {
+                    let base = Arc::clone(&base);
+                    let mut base = base.lock().unwrap();
+                    base.emit_signal("document_title_changed", &[title.to_variant()]);
+                }
+            })
+            .with_navigation_handler({
+                let navigation_handler = Arc::clone(&navigation_handler);
+                move |url: String| {
+                    let handler = navigation_handler.lock().unwrap();
+                    if handler.is_valid() {
+                        let result = handler.callv(&varray![url.to_variant()]);
+                        return result.booleanize();
+                    }
+                    false
+                }
+            })
+            ;
 
         if !self.url.is_empty() && !self.html.is_empty() {
             godot_error!("[Godot WRY] You have entered both a URL and HTML code. You may only enter one at a time.")
@@ -611,6 +658,16 @@ impl WebView {
         if let Some(webview) = &self.webview {
             let _ = webview.zoom(scale_factor);
         }
+    }
+
+    #[func]
+    fn set_navigation_handler(&mut self, callable: Callable) {
+        self.navigation_handler = callable;
+    }
+
+    #[func]
+    fn set_new_window_req_handler(&mut self, callable: Callable) {
+        self.new_window_req_handler = callable;
     }
 }
 


### PR DESCRIPTION
- Fixes https://github.com/doceazedo/godot_wry/issues/51

# Note:
- The update on the svg icon (scale in editor) makes the icon appear same size as other nodes.
- Adds drag and drop support (basic, just yes/no for now)