### PR TITLE
feat: initialize GTK on Linux platform

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -156,6 +156,9 @@ impl WebView {
             return;
         }
 
+        #[cfg(target_os = "linux")]
+        gtk::init().expect("Failed to initialize GTK");
+
         let window = GodotWindow;
 
         // remove WS_CLIPCHILDREN from the window style


### PR DESCRIPTION
# Fix: GTK not initialized on Linux (X11) — webview fails to render

## Problem

On Linux with X11 (e.g. Linux Mint), the WebView node panics when the scene runs and the webview does not render.

**Error:**
<img width="1674" height="291" alt="image" src="https://github.com/user-attachments/assets/787a0858-6f26-4d64-acce-0bc65961ef9b" />
```
[panic webkit2gtk-2.0.1/src/auto/application_info.rs:21] GTK has not been initialized. Call `gtk::init` first.

godot-rust function call failed: WebView::ready()
Reason: GTK has not been initialized. Call `gtk::init` first.
```

webkit2gtk requires GTK to be initialized before any WebKit/WebContext usage. Previously, `gtk::init()` was only called inside `GodotWindow::window_handle()`, which runs when `build_as_child(&window)` executes — but webkit2gtk touches GTK earlier (e.g. during `WebContext::new()`), so the check in `application_info.rs` fails.

## Solution

Call `gtk::init()` at the start of `create_webview()` on Linux, before creating `WebContext` or the `WebViewBuilder`, so GTK is initialized before any WRY/webkit2gtk code runs.

**Change:** one Linux-only block in `rust/src/lib.rs` (after the headless check, before `let window = GodotWindow`):

```rust
#[cfg(target_os = "linux")]
gtk::init().expect("Failed to initialize GTK");
```

## Testing

Verified on **Linux Mint 22.1 Cinnamon** with the following setup:

| | |
|---|---|
| **OS** | Linux Mint 22.1 Cinnamon |
| **Kernel** | 6.4.8 / 6.8.0-88-generic |
| **CPU** | AMD Ryzen 5 5600H with Radeon Graphics (6 cores) |
| **RAM** | 22.8 GiB |
| **GPU** | NVIDIA GeForce RTX 3050 Mobile, AMD Radeon Vega (integrated) |
| **Display** | X11 |

- **Before fix:** Running a scene with a WebView produced the panic above and the webview did not render.
- **After fix:** The same project runs without errors and the webview renders correctly (e.g. GitHub page for `doceazedo/godot_wry` inside the Godot window).

Screenshots attached: plugin working after the fix with the specs above.
<img width="1751" height="735" alt="image" src="https://github.com/user-attachments/assets/e30f8022-f1df-40a6-98c9-1b08113fbfde" />

