### PR TITLE
Fix url paths on linux + defer calls to avoid errors in godot

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -364,7 +364,7 @@ impl WebView {
                     }
                     
                     // if we get here, this is a regular IPC message
-                    base.emit_signal("ipc_message", &[body.to_variant()]);
+                    base.call_deferred("emit_signal", &["ipc_message".to_variant(), body.to_variant()]); 
                 }
             })
             .with_on_page_load_handler({
@@ -373,8 +373,8 @@ impl WebView {
                     let mut base = base.lock().unwrap();
 
                     match event {
-                        PageLoadEvent::Started => base.emit_signal("page_load_started", &[url.to_variant()]),
-                        PageLoadEvent::Finished => base.emit_signal("page_load_finished", &[url.to_variant()]),
+                        PageLoadEvent::Started => base.call_deferred("emit_signal", &["page_load_started".to_variant(), url.to_variant()]),
+                        PageLoadEvent::Finished => base.call_deferred("emit_signal", &["page_load_finished".to_variant(), url.to_variant()]),
                     };
                 }
             })
@@ -544,7 +544,16 @@ impl WebView {
 
         if let Some(stripped) = url_str.strip_prefix("res://") {
             let path = stripped.replace("\\", "/");
-            url_str = format!("http://res.{}", path);
+            
+            #[cfg(target_os = "linux")]
+            {
+                url_str = format!("res://{}", path);
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                url_str = format!("http://res.{}", path);
+            }
         }
 
         if let Some(webview) = &self.webview {


### PR DESCRIPTION
Paths like this: "res://HUD/index.html" created this url before: "http://res.HUD/index.html". This only works for Webview2. WebkitGTK directly uses the scheme "res://HUD/index.html". So added a os check to ensure we use proper url.

Previously when calling
```gd
webview.post_message(...) 
```
before the page properly loaded (i assume that is what caused it)

Threw this error:
```
E 0:00:01:250   ui_overlay.gd:77 @ _on_page_load_finished(): [panic /home/max/.cargo/git/checkouts/gdext-067f4b88e7bd088f/d4fb159/godot-core/src/storage/single_threaded.rs:64]
  Gd<T>::bind() failed, already bound; T = godot_wry::WebView.
    Make sure to use `self.base_mut()` or `self.base()` instead of `self.to_gd()` when possible.
    Details: cannot borrow while accessible mutable borrow exists.
  <C++-Quelle>  /home/max/.cargo/git/checkouts/gdext-067f4b88e7bd088f/d4fb159/godot-core/src/private.rs:262 @ godot_core::private::set_gdext_hook::{{closure}}()
  <Stacktrace>  ui_overlay.gd:77 @ _on_page_load_finished()
```

This has been fixed by deferring the signal emission.